### PR TITLE
(DO NOT MERGE) Add test that shows that alterations modify original template 

### DIFF
--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -73,6 +73,31 @@ suite('Valid Schema Tests', () => {
     assert.equal(json.optEmpty.length, 0);
   });
 
+  test('default values with push don\'t alter schema', () => {
+    let json = {};
+    let error = validate(
+        json,
+        'http://localhost:1203/default-array-obj-schema');
+    assert.equal(error, null);
+
+    // Here we'll push a value onto the default that was added
+    // to our json. If this works _incorrectly_, this will be part
+    // of the future defaults.
+    json.optArray.push('another-string');
+
+    let json2 = {};
+    error = validate(
+        json2,
+        'http://localhost:1203/default-array-obj-schema');
+    assert.equal(error, null);
+
+    // Now we can try to assert that the default hasn't been altered
+    // by our previous actions.
+    assert.equal(json2.optArray.length, 1);
+    assert.equal(json2.optArray[0], 'my-default-value');
+    assert.equal(json2.optEmpty.length, 0);
+  });
+
   test('no opts', async (done) => {
     let v = await validator();
     assert(v);


### PR DESCRIPTION
If this test does what it should be doing, then this shows that the library _isn't_ doing what we want, right?

Running tests with this test fails as follows:

```
  1 failing

  1) Valid Schema Tests default values with push don't alter schema:

      AssertionError: 2 == 1
      + expected - actual

      -2
      +1

      at Context.<anonymous> (test/validate_test.js:96:12)



npm ERR! Test failed.  See above for more details.
```
