### PR TITLE
Only deploy from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,4 @@ deploy:
   on:
     tags: true
     repo: taskcluster/taskcluster-lib-validate
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,25 @@
 language: node_js
 sudo: false
 node_js:
-  - '0.12'
-  - '4'
-  - '5'
-  - '6'
+- '0.12'
+- '4'
+- '5'
+- '6'
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
+    - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
+    - g++-4.8
 script: npm test
 env:
   global:
-    - DEBUG='taskcluster-lib-validate test'
-    - CXX=g++-4.8
-
+  - DEBUG='taskcluster-lib-validate test'
+  - CXX=g++-4.8
 notifications:
   irc:
     channels:
-      # encrpyted string was "irc.mozilla.org#taskcluster-bots
-      - secure: "CszUdF4z8i+1dKdVyiPyDe+dGxBKCwJkDnhCPuNk9jSmRga8VFiBaBeUWbwksCUxBjLE4S2bRTEJ7bE+X3JHfOhJitKSle0Jjyv/fLKdaxNjTXaG0+zis5nvRQOMroMqkEKJHVeipPiv9pAvSNMaYLA9vF1CW/KGOfFOQUGthbiX9y4JZguSnCLcfpAm3hr1u7dAr8X0gPXVKUO+P4gEisWXw9XetI/ae1AeZ5pJ1V0N/Dbi+XcR5o4iH78OnoTT/jQh0V2lTNm1auNte+V68dOvJmrvNMHbCbch4fI6OEtGyrmoe501QO1vSHRXzIJP2Vm0Yn9zKZx+ofd4cFOjjr3wJi2FP9Ei0tM0N+XDiYMBCP70qOMpLm9et4a/dzWEwiO8ussS4jTRt23fvtl1Lm9n7tUm1r/A/bWHj99ORGMdPrIE7eFYRlN0yuYFsx/8B7917WFw5lAfIsVV0fq5YOa6Q3Dm85OCZTkJUZyirsNQS+XuRHPLcn0QCAgIIlfSqNWQfDrKrXl8UnxreQb7X2N8GgiWuWb2gQpl//rFoRlpEjQnNjxJ9cuukBLSObWBwjY8+dWJFoLZzVaZLNyLpwiPV1lFIZfffgO63d+5/koavKrO0V4/UuEyhv1qOuQsyiY2nqtXwRogXqxuFQknOC/LzZZBp9V5JaRcjdyzEAo="
+    - secure: CszUdF4z8i+1dKdVyiPyDe+dGxBKCwJkDnhCPuNk9jSmRga8VFiBaBeUWbwksCUxBjLE4S2bRTEJ7bE+X3JHfOhJitKSle0Jjyv/fLKdaxNjTXaG0+zis5nvRQOMroMqkEKJHVeipPiv9pAvSNMaYLA9vF1CW/KGOfFOQUGthbiX9y4JZguSnCLcfpAm3hr1u7dAr8X0gPXVKUO+P4gEisWXw9XetI/ae1AeZ5pJ1V0N/Dbi+XcR5o4iH78OnoTT/jQh0V2lTNm1auNte+V68dOvJmrvNMHbCbch4fI6OEtGyrmoe501QO1vSHRXzIJP2Vm0Yn9zKZx+ofd4cFOjjr3wJi2FP9Ei0tM0N+XDiYMBCP70qOMpLm9et4a/dzWEwiO8ussS4jTRt23fvtl1Lm9n7tUm1r/A/bWHj99ORGMdPrIE7eFYRlN0yuYFsx/8B7917WFw5lAfIsVV0fq5YOa6Q3Dm85OCZTkJUZyirsNQS+XuRHPLcn0QCAgIIlfSqNWQfDrKrXl8UnxreQb7X2N8GgiWuWb2gQpl//rFoRlpEjQnNjxJ9cuukBLSObWBwjY8+dWJFoLZzVaZLNyLpwiPV1lFIZfffgO63d+5/koavKrO0V4/UuEyhv1qOuQsyiY2nqtXwRogXqxuFQknOC/LzZZBp9V5JaRcjdyzEAo=
     on_success: change
     on_failure: always
     template:
@@ -29,3 +27,11 @@ notifications:
     - 'Change view : %{compare_url}'
     - 'Build details : %{build_url}'
     - 'Commit message : %{commit_message}'
+deploy:
+  provider: npm
+  email: taskcluster-accounts@mozilla.com
+  api_key:
+    secure: XR7JmLhmTV0LNfKuKvxF4ayTeC3780JUFmlmTiGZDSbKchbDEjjy1wJuyIg/yRSAllHuynwIFJJUA62REbqwlc6ajhEpyAWFXGmd67aKxfF1sPGg/sp3Dz62ecm2VeW4/T1mEqAzgIDTveFtxsnUHCEVSYFo5QQeHpWktAZLN6LiwtAdhPvfAb292nhYruw+0BXA9MNYbOfXlU0O/gwqkV66Vz/hd3Yb34ouZaQ1KzHS8EWhkIgGeDs937HQymnrDOTzfosx7obuzwYd0jG//KVAqIoGUmiRlyp8k11eotbnvcCiLdAxt4Y2DDcrgObsh5y8izJ0zsUffRGpI6lRDBs+fEb3nUKSA7Q+3AGscZMthAsPXwx/CBFtSLzSFnm+8ULO2Y8231I2hn/yHO/5OyK+v2qwSF3Y2SByCvIXoGdxQWcssgAPboEpCOXgGPytw5s1D9RClUnkV1BaPIYLZXK3+BBt0aaAHRB+9J2mwvftsnjJP299x3QSCuI6AUe9oxY2X64NHgUXlcqBAWvKEgXhoL5Smtsi8ZbAzjgCeHrDVTvBFkaaJsbum7h6ZmP4UsL4HOQ9IWETmpy7geNXPtAEtqdUKAtkeWPqbaYFHS3qKn6LLWsv4jScdC4pc6Xlusn93E3jGN83CZXadWxOwd7Ne1jQH97F8w12hb12UwY=
+  on:
+    tags: true
+    repo: taskcluster/taskcluster-lib-validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ deploy:
   on:
     tags: true
     repo: taskcluster/taskcluster-lib-validate
-    branch: master
+    node: '5'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ content matches established schemas. This is a replacement for
 Requirements
 ------------
 
-This is tested on and should run on any of node `{0.12, 4, 5}`.
+This is tested on and should run on any of node `{0.12, 4, 5, 6}`.
 
 Usage
 -----

--- a/test/package_test.js
+++ b/test/package_test.js
@@ -1,0 +1,15 @@
+suite('Package', () => {
+  let assert = require('assert');
+  let pack = require('../package.json');
+  let exec = require('child_process');
+
+  test('git tag must match package version', function() {
+    let tag = exec.execSync('git tag -l --contains HEAD').toString().trim();
+    if (tag === '') {
+      console.log('    No git tag, no need to check tag!');
+      this.skip();
+    }
+    assert.equal('v' + pack.version, tag);
+  });
+
+});


### PR DESCRIPTION
This is the same thing as https://github.com/taskcluster/taskcluster-lib-monitor/pull/22 and is ready to go once that is ready as well.
