### PR TITLE
One option to support remote refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,18 +23,20 @@
     "js-yaml": "^3.5.3",
     "lodash": "^4.5.1",
     "promise": "^7.0.4",
+    "request": "^2.72.0",
     "url-join": "^1.1.0",
     "walk": "^2.3.9"
   },
   "devDependencies": {
     "babel-compile": "^2.0.0",
-    "babel-preset-taskcluster": "^3.0.0",
     "babel-eslint": "^6.0.2",
+    "babel-preset-taskcluster": "^3.0.0",
     "eslint-config-taskcluster": "^2.0.0",
     "eslint-plugin-taskcluster": "^1.0.0",
     "mocha": "2.5.3",
     "mocha-eslint": "^2.0.1",
     "mock-aws-s3": "^2.1.0",
+    "nock": "^8.0.0",
     "rimraf": "^2.5.2",
     "source-map-support": "^0.4.0"
   },

--- a/test/remote-schemas/test-remote-schema.json
+++ b/test/remote-schemas/test-remote-schema.json
@@ -1,0 +1,15 @@
+{
+  "id":           "http://localhost:1204/test-remote-schema.json#",
+  "$schema":      "http://json-schema.org/draft-04/schema#",
+  "title":        "test remote json schema",
+  "type":         "object",
+  "properties": {
+    "value": {
+      "type":           "integer",
+      "minimum":        10,
+      "maximum":        12
+    }
+  },
+  "additionalProperties":   false,
+  "required": ["value"]
+}

--- a/test/schemas/remote-ref-test-schema.json
+++ b/test/schemas/remote-ref-test-schema.json
@@ -1,0 +1,11 @@
+{
+  "id":           "http://localhost:1203/remote-ref-test-schema.json#",
+  "$schema":      "http://json-schema.org/draft-04/schema#",
+  "title":        "test json schema",
+  "type":         "object",
+  "properties": {
+    "reference":       {"$ref": "http://localhost:1204/test-remote-schema.json#"}
+  },
+  "additionalProperties":   false,
+  "required": ["reference"]
+}


### PR DESCRIPTION
I'm adding this to tc-hooks and it uses remote references. We could add an argument that you have to pass in specifying all of the remote refs to load when this thing is instantiated, or we could go about it like this. Which approach do you like more? I can confirm this method works and it avoids situations where people forget to add it as an argument.

Any other ideas for how you would rather see this done?
