### PR TITLE
Remove console.log on normal case

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -35,7 +35,7 @@ async function validator(options) {
       cfg.constants = yaml.safeLoad(fs.readFileSync(fullpath, 'utf-8'));
     } catch (err) {
       if (err.code == 'ENOENT') {
-        console.log('Constants file does not exist, setting constants to {}');
+        debug('Constants file does not exist, setting constants to {}');
         cfg.constants = {};
       } else {
         throw err;


### PR DESCRIPTION
I think when I wrote this I didn't understand how we set up debugging in production. Right now this basically shows up between half of the tests in half of our services. It is annoying and does not provide much value. I apologize for the pixels I have wasted for this silly log line.