### PR TITLE
Bug 1441624 - Additional details for additional properties

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -135,7 +135,7 @@ async function validator(options) {
     if (ajv.errors) {
       _.forEach(ajv.errors, function(error) {
         if (error.params['additionalProperty']) {
-          error.message += ':' + JSON.stringify(error.params['additionalProperty']);
+          error.message += ': ' + JSON.stringify(error.params['additionalProperty']);
         }
       });
       return [

--- a/src/validate.js
+++ b/src/validate.js
@@ -134,7 +134,9 @@ async function validator(options) {
     ajv.validate(id, obj);
     if (ajv.errors) {
       _.forEach(ajv.errors, function(error) {
-        error.message += '\n' + JSON.stringify(error.params);
+        if (error.params['additionalProperty']) {
+          error.message += ':' + JSON.stringify(error.params['additionalProperty']);
+        }
       });
       return [
         '\nSchema Validation Failed!',

--- a/src/validate.js
+++ b/src/validate.js
@@ -133,6 +133,9 @@ async function validator(options) {
     id += '#';
     ajv.validate(id, obj);
     if (ajv.errors) {
+      _.forEach(ajv.errors, function(error) {
+        error.message += '\n' + JSON.stringify(error.params);
+      });
       return [
         '\nSchema Validation Failed!',
         '\nRejecting Schema: ',

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -44,10 +44,11 @@ suite('Valid Schema Tests', () => {
   });
 
   test('default values are inserted', () => {
-    let json = {value: 42};
+    let json = {value: 42, value1: 50};
     let error = validate(
       json,
       'http://localhost:1203/default-schema');
+    console.log('..error', error);
     assert.equal(error, null);
     assert.equal(json.value, 42);
     assert.equal(json.optionalValue, 'my-default-value');

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -44,11 +44,10 @@ suite('Valid Schema Tests', () => {
   });
 
   test('default values are inserted', () => {
-    let json = {value: 42, value1: 50};
+    let json = {value: 42};
     let error = validate(
       json,
       'http://localhost:1203/default-schema');
-    console.log('..error', error);
     assert.equal(error, null);
     assert.equal(json.value, 42);
     assert.equal(json.optionalValue, 'my-default-value');
@@ -123,4 +122,12 @@ suite('Valid Schema Tests', () => {
     assert(_.includes(_.keys(schemas), 'default-schema.json'));
   });
 
+  test('message specifies unwanted additional property', () => {
+    let error = validate(
+      {value: 42, unwanted_value: 1729},
+      'http://localhost:1203/default-schema');
+    debug(error);
+    assert.notEqual(error, null);
+    assert(error.includes('data should NOT have additional properties:"unwanted_value"'));
+  });
 });

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -128,6 +128,6 @@ suite('Valid Schema Tests', () => {
       'http://localhost:1203/default-schema');
     debug(error);
     assert.notEqual(error, null);
-    assert(error.includes('data should NOT have additional properties:"unwanted_value"'));
+    assert(error.includes('data should NOT have additional properties: "unwanted_value"'));
   });
 });


### PR DESCRIPTION
For every error in `validate` ajv returns an [error object](https://github.com/epoberezkin/ajv#validation-errors). Each error object has a list of [params](https://github.com/epoberezkin/ajv#error-parameters) with additional information about the error. This contains the additional properties that `data` should not have.
In the following commit, I have modified the error message as ` default_message + params`. This is however not specific to the type of error we are targeting.
I have also broken a test in `test/validate_test.js` only to demonstrate the modified error message.
```
Schema Validation Failed!
Rejecting Schema: http://localhost:1203/default-schema.json#
Errors:
  * data should NOT have additional properties
{"additionalProperty":"value1"}
```
