### PR TITLE
Bug 1508395 - use abstract URLs that are /-relative, instead of 'taskcluster:..'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const schemaset = new SchemaSet({
 
 // The loaded schemas are easily accessible
 console.log(schemaset.abstractSchemas())
-// ↳ [{'id': 'taskcluster:/schemas/someservice/first-schema.json#', ...}, ...]
+// ↳ [{'id': '/schemas/someservice/first-schema.json#', ...}, ...]
 ```
 
 ### Schema References
@@ -47,7 +47,7 @@ Thus `{$ref: 'widget-description.json#'}` is allowed, but `{$ref: '/schemas/anot
 The rationale is that a service must be self-consistent, and any change to a schema requires a corresponding change to the code that handles the data.
 A schema from another service could change at any time, invalidating the code in this service.
 
-When initially loading the schema files, the `$id` is of the form `taskcluster:/schemas/<serviceName>/<filename>.json#`.
+When initially loading the schema files, the `$id` is of the form `/schemas/<serviceName>/<filename>.json#`.
 The schemas have not yet been deployed at a specific root URL, and thus no fixed base location is known.
 Such schemas are referred to as "abstract schemas", and are used during the Taskcluster build process to generate documentation and client libraries.
 

--- a/src/schemaset.js
+++ b/src/schemaset.js
@@ -12,7 +12,7 @@ const publish = require('./publish');
 const {renderConstants, checkRefs} = require('./util');
 const rootdir = require('app-root-dir');
 
-const ABSTRACT_SCHEMA_ROOT_URL = 'taskcluster:';
+const ABSTRACT_SCHEMA_ROOT_URL = '';
 
 class SchemaSet {
   constructor(options) {

--- a/test/schemaset_test.js
+++ b/test/schemaset_test.js
@@ -20,7 +20,7 @@ suite('schemaset_test.js', () => {
     assert(_.includes(_.keys(schemas), 'v1/default-schema.json'));
     assert.equal(
       schemas['v1/default-schema.json'].$id,
-      'taskcluster:/schemas/whatever/v1/default-schema.json#'
+      '/schemas/whatever/v1/default-schema.json#'
     );
   });
 

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -28,9 +28,9 @@ suite('test_util.js', function() {
         /rooted URIs *. are not allowed/);
     });
 
-    test('on a schema with a "taskcluster:.." ref (not allowed)', function() {
+    test('on a schema with a /-relative ref (not allowed)', function() {
       assert.throws(
-        () => checkRefs(schemaWith({$ref: 'taskcluster:/schemas/foo.json'}), 'thisservice'),
+        () => checkRefs(schemaWith({$ref: '/schemas/foo.json'}), 'thisservice'),
         Error,
         /absolute URIs *. are not allowed/);
     });


### PR DESCRIPTION
Per taskcluster/taskcluster-rfcs#128